### PR TITLE
fix directory separators in windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ module.exports = function (options) {
 		var relativePath = file.path.replace(file.cwd + '/', '');
 		var fileBase = file.base?path.resolve(file.base) : file.cwd;
 		var localRelativePath = file.path.replace(path.join(fileBase, localPath), '');
-		var finalRemotePath = path.join(remotePath, localRelativePath);
+		var finalRemotePath = path.join(remotePath, localRelativePath).replace(/\\/g, '/');
 		
 		
 		// MDRAKE: Would be nice - pool requests into single connection


### PR DESCRIPTION
addresses #2 

the path module generates normalized paths based on the local system, and I don't see anything to change which separator it uses, so this just changes the finalRemotePath to all forward slash so it will work on a remote linux system from a local windows system. forward slashes would probably still work on a remote windows system anyway

tested this on windows and it uploads to the right place now
