### PR TITLE
Option to modify the default timeout when attempting to connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ Default: `.ftppass`
 
 A path relative to the project root to a JSON formatted file containing auth information.
 
+#### options.timeout
+type `int`
+Default: Currently set by ssh2 as `10000` milliseconds.
+
+An integer in milliseconds specifying how long to wait for a server response.
+
 
 ##Authentication
 
@@ -165,3 +171,4 @@ Some awesome work via @mscdex addressed this issue. Please make sure you have th
 ## License
 
 [MIT](http://opensource.org/licenses/MIT)
+

--- a/index.js
+++ b/index.js
@@ -201,7 +201,9 @@ module.exports = function (options) {
             connection_options.passphrase = key.passphrase;
         }
 
-
+        if(options.timeout){
+            connection_options.readyTimeout = options.timeout;
+        }
 
         c.connect(connection_options);
 


### PR DESCRIPTION
When working with slower servers, the default timeout specified by ssh2 is not enough time to get a successful handshake. Added the option to set a timeout which would allow an extended wait.
