### PR TITLE
Fixed task not properly finishing when using a callback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [gulp](http://gulpjs.com)-sftp [![Build Status](https://travis-ci.org/fulf/gulp-sftp.svg?branch=master)](https://travis-ci.org/fulf/gulp-sftp)
+# [gulp](http://gulpjs.com)-sftp-new [![Build Status](https://travis-ci.org/fulf/gulp-sftp.svg?branch=master)](https://travis-ci.org/fulf/gulp-sftp)
 
 > Upload files via SSH
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# [gulp](http://gulpjs.com)-sftp [![Build Status](https://travis-ci.org/gtg092x/gulp-sftp.svg?branch=master)](https://travis-ci.org/gtg092x/gulp-sftp)
+# [gulp](http://gulpjs.com)-sftp [![Build Status](https://travis-ci.org/fulf/gulp-sftp.svg?branch=master)](https://travis-ci.org/fulf/gulp-sftp)
 
 > Upload files via SSH
 
 Useful for uploading and deploying things via sftp. Right now this plugin just uploads everything. Caching and hash comparison are two TODO items.  
 
-[![NPM](https://nodei.co/npm/gulp-sftp.png?downloads=true&stars=true)](https://nodei.co/npm/gulp-sftp/)
+[![NPM](https://nodei.co/npm/gulp-sftp.png?downloads=true&stars=true)](https://nodei.co/npm/gulp-sftp-new/)
 
 ## Install
 
 ```bash
-$ npm install --save-dev gulp-sftp
+$ npm install --save-dev gulp-sftp-new
 ```
 
 
@@ -17,7 +17,7 @@ $ npm install --save-dev gulp-sftp
 
 ```js
 var gulp = require('gulp');
-var sftp = require('gulp-sftp');
+var sftp = require('gulp-sftp-new');
 
 gulp.task('default', function () {
 	return gulp.src('src/*')
@@ -141,7 +141,7 @@ For better security, save authentication data in a json formatted file named `.f
 
 ```js
 var gulp = require('gulp');
-var sftp = require('gulp-sftp');
+var sftp = require('gulp-sftp-new');
 
 gulp.task('default', function () {
 	return gulp.src('src/*')
@@ -188,7 +188,7 @@ Version 0.1.2 has an issue for Windows clients when it comes to resolving remote
 
 ~~To solve problems related to [ssh2](https://github.com/mscdex/ssh2) closures, try to use streams instead of buffers. Do this by passing `{buffer:false}` as an option with `gulp.src`. This isn't always an option, so I would suggest exploring ways to move between streams and buffers. Lars Kappert has a [great article on managing this](https://medium.com/web-code-junk/a2010c13d3d5).~~
 
-Some awesome work via @mscdex addressed this issue. Please make sure you have the latest version or greater of gulp-sftp (0.1.1) and the latest version or greater of ssh2 (0.3.4) and you should not see abrupt disconnects with large files.
+Some awesome work via @mscdex addressed this issue. Please make sure you have the latest version or greater of gulp-sftp-new (0.1.1) and the latest version or greater of ssh2 (0.3.4) and you should not see abrupt disconnects with large files.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Useful for uploading and deploying things via sftp. Right now this plugin just uploads everything. Caching and hash comparison are two TODO items.  
 
-[![NPM](https://nodei.co/npm/gulp-sftp.png?downloads=true&stars=true)](https://nodei.co/npm/gulp-sftp-new/)
+[![NPM](https://nodei.co/npm/gulp-sftp-new.png?downloads=true&stars=true)](https://nodei.co/npm/gulp-sftp-new/)
 
 ## Install
 

--- a/index.js
+++ b/index.js
@@ -162,7 +162,6 @@ module.exports = function (options) {
                 self.emit('error', new gutil.PluginError('gulp-sftp', "SFTP abrupt closure"));
             }
             gutil.log('Connection :: close',had_error!==false?"with error":"");
-            if(options.callback) options.callback();
         });
 
 
@@ -319,7 +318,10 @@ module.exports = function (options) {
             sftpCache.end();
         if(connectionCache)
             connectionCache.end();
-
-        cb();
+        
+        if(options.callback) 
+            options.callback();
+        else
+            cb();
     });
 };

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "gulp-sftp",
-  "version": "0.1.5",
+  "name": "gulp-sftp-new",
+  "version": "0.1.6",
   "description": "Upload files via SSH",
   "license": "MIT",
-  "repository": "gtg092x/gulp-sftp",
-  "homepage": "https://github.com/gtg092x/gulp-sftp/",
+  "repository": "fulf/gulp-sftp",
+  "homepage": "https://github.com/fulf/gulp-sftp",
   "bugs": {
-    "url" : "https://github.com/gtg092x/gulp-sftp/issues"
+    "url" : "https://github.com/fulf/gulp-sftp/issues"
   },
   "author": {
     "name": "Matthew Drake",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "gulp-sftp-new",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "description": "Upload files via SSH",
   "license": "MIT",
   "repository": "fulf/gulp-sftp",
   "homepage": "https://github.com/fulf/gulp-sftp",
   "bugs": {
-    "url" : "https://github.com/fulf/gulp-sftp/issues"
+    "url": "https://github.com/fulf/gulp-sftp/issues"
   },
   "author": {
     "name": "Matthew Drake",


### PR DESCRIPTION
If you tried to run a callback function and the SFTP realized it had no file to upload, the task would just hang without being properly finished.
