### PR TITLE
Deprecating existsSync with statSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,11 +76,9 @@ module.exports = function (options) {
                 if (key.location[i].substr(0,2) === '~/')
                     key.location[i] = path.resolve(home,key.location[i].replace(/^~\//,""));
 
-
             for(var i=0,keyPath;keyPath=key.location[i++];){
-
-
-                if(fs.accessSync(keyPath)){
+                var stat = fs.statSync(keyPath);
+                if (stat && stat.isFile()) {
                     key.contents = fs.readFileSync(keyPath);
                     break;
                 }

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ module.exports = function (options) {
             for(var i=0,keyPath;keyPath=key.location[i++];){
 
 
-                if(fs.existsSync(keyPath)){
+                if(fs.accessSync(keyPath)){
                     key.contents = fs.readFileSync(keyPath);
                     break;
                 }


### PR DESCRIPTION
Ran into issue of my privateKey having an incorrect path but errors only showed Authentication Error. Looks like the existsSync did not have proper error handling whereas statSync does.

However might throw error if default key locations do not exist (/.ssh/xxx)

API Reference:
https://nodejs.org/api/fs.html#fs_fs_existssync_path