### PR TITLE
Suppress error for existing directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,8 +247,10 @@ module.exports = function (options) {
                 sftp.mkdir(d, {mode: '0755'}, function(err){//REMOTE PATH
 
                     if(err){
-                        //assuming that the directory exists here, silencing this error
-                        gutil.log('SFTP error or directory exists:', gutil.colors.red(err + " " +d));
+                        // Supressing SFTP Error Code 11 (0x000B) SSH_ERROR_FILE_ALREADY_EXISTS
+                        if(err.code !== 11){
+                            gutil.log('SFTP error:', gutil.colors.red(err + " " +d));
+                        }
                     }else{
                         gutil.log('SFTP Created:', gutil.colors.green(d));
                     }


### PR DESCRIPTION
Proposed solution for https://github.com/gtg092x/gulp-sftp/issues/34

Doesn't actually check if directories exist or not, so the `mkdir` command is still sent regardless, but simply suppresses the error if the directory exists.
