### PR TITLE
Feature: clear destination before upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
   - '6.11.1'
-script: 'sudo $(which npm) test'
+script: 'npm test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - '0.10'
+  - '6.11.1'
 script: 'sudo $(which npm) test'

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ Default: `'/'`
 
 The remote path to upload to. If this path does not yet exist, it will be created, as well as the child directories that house your files.
 
+#### options.clearDestination
+
+Type: `Boolean`
+Default: `false`
+
+Clear the `options.remotePath` directory before upload.
+
 #### options.remotePlatform
 
 Type: `String`

--- a/clear.js
+++ b/clear.js
@@ -1,0 +1,42 @@
+const async = require('async');
+const path = require('path');
+const gutil = require('gulp-util');
+
+function log(...msg) {
+    msg.unshift('gulp-sftp:');
+    gutil.log.apply(console, msg);
+}
+
+function isDirectory(entry) {
+    // Save one network call for 'stat' by checking the 'd' flag in longname:
+    // drwxr--r-- 1 bar bar 718 Dec 8 2009 foo
+    return entry.longname.startsWith('d');
+}
+
+/*
+ * Delete contents of a directory on an SFTP server
+ * @param {SFTPStream} sftp
+ * @param {string} dirPath Remote directory
+ * @param {(error) -> ()} callback Callback
+ */
+function clearDirectory(sftp, dirPath, callback) {
+    function deleteEntry(entry, callback) {
+        var entryPath = path.join(dirPath, entry.filename);
+
+        if (isDirectory(entry)) {
+            clearDirectory(sftp, entryPath, () => {
+                log(gutil.colors.green('Deleting remote directory'), entryPath);
+                sftp.rmdir(entryPath, callback);
+            });
+        } else {
+            log(gutil.colors.green('Deleting remote file'), entryPath);
+            sftp.unlink(entryPath, callback);
+        }
+    }
+
+    sftp.readdir(dirPath, (err, entries) => {
+        async.map(entries, deleteEntry, callback);
+    });
+}
+
+module.exports.clearDirectory = clearDirectory;

--- a/clear.test.js
+++ b/clear.test.js
@@ -60,10 +60,12 @@ function mockSFTP(vfs) {
             const dirEntry = resolvePath(vfs, path);
 
             try {
-                const ftpEntries = Object.entries(dirEntry).map(([name, contents]) => ({
-                    filename: name,
-                    longname: contents instanceof Object ? dirLongName : fileLongName
-                }));
+                const ftpEntries = Object.keys(dirEntry)
+                    .map((k) => [k, dirEntry[k]])
+                    .map(([name, contents]) => ({
+                        filename: name,
+                        longname: contents instanceof Object ? dirLongName : fileLongName
+                    }));
 
                 try { callback(null, ftpEntries); } catch (callbackFailure) { console.error(callbackFailure) }
             } catch (e) {

--- a/clear.test.js
+++ b/clear.test.js
@@ -1,0 +1,283 @@
+const {clearDirectory} = require('./clear');
+const path = require('path');
+
+/**
+ * Resolve a a subtree by filesystem-like path in an object tree
+ * @param {Object} vfs 
+ * @param {string} entryPath 
+ */
+function resolvePath(vfs, entryPath) {
+    if (entryPath === '/') {
+        return vfs;
+    }
+    const segments = entryPath.split(path.sep);
+    if (segments[0] === '') {
+        segments.shift()
+    }
+
+    return segments.reduce((tree, segment) => tree[segment], vfs);
+}
+
+describe('resolvePath', () => {
+    it('resolves root', () => {
+        const vfs = {};
+
+        expect(resolvePath(vfs, '/')).toBe(vfs);
+    })
+
+    it('returns undefined for missing entries', () => {
+        expect(resolvePath({}, '/test')).toBeUndefined();
+    })
+
+    it('resolves first level item', () => {
+        const vfs = { 'a': 'passed' };
+
+        expect(resolvePath(vfs, '/a')).toBe("passed");
+    })
+
+    it('resolves deep value', () => {
+        const vfs = { 'a': { 'b': { 'c': { 'd': "deep passed" }}}};
+
+        expect(resolvePath(vfs, '/a/b/c/d')).toBe("deep passed")
+    })
+
+    it('resolves relative paths', () => {
+        const vfs = { 'a': { 'b': "relative passed" }};
+
+        expect(resolvePath(vfs, 'a/b')).toBe("relative passed")
+    })
+})
+
+
+function mockSFTP(vfs) {
+    // The following samples are taken from a real FTP server
+    const dirLongName  = 'drwxr-x---    2 user www            13 Jul 23 00:59 tmp'
+    const fileLongName = '-rw-r-----    1 user www           760 Jul 23 00:59 main.css'
+    const deletions = []
+
+    return {
+        'readdir': jest.fn((path, callback) => {
+            const dirEntry = resolvePath(vfs, path);
+
+            try {
+                const ftpEntries = Object.entries(dirEntry).map(([name, contents]) => ({
+                    filename: name,
+                    longname: contents instanceof Object ? dirLongName : fileLongName
+                }));
+
+                try { callback(null, ftpEntries); } catch (callbackFailure) { console.error(callbackFailure) }
+            } catch (e) {
+                callback(e);
+            }
+        }),
+
+        'unlink': jest.fn((filepath, callback) => {
+            const {dir, base} = path.parse(filepath);
+            const dirEntry = resolvePath(vfs, dir);
+
+            if (dirEntry[base] instanceof Object) {
+                callback(`Error: cannot unlink a directory: ${filepath}`)
+            } else if (dirEntry[base] === undefined) {
+                callback(`Error: file ${filepath} does not exist`)
+             } else {
+                delete dirEntry[base];
+                deletions.push(filepath);
+                callback();
+            }
+        }),
+
+        'rmdir': jest.fn((dirpath, callback) => {
+            const {dir, base} = path.parse(dirpath);
+            const parentDirEntry = resolvePath(vfs, dir);
+
+            if (parentDirEntry[base] instanceof Object) {
+                delete parentDirEntry[base];
+                deletions.push(dirpath);
+                callback();
+            } else {
+                callback(`Error: ${dirpath} is not a directory`)
+            }
+        }),
+
+        'deletions': deletions
+    }
+}
+
+describe('mockSFTP', () => {
+    let vfs;
+    let sftp;
+    let callback;
+
+    beforeEach(() => {
+        vfs = {
+            'dir1': [],
+            'dir2': {
+                'a.txt': null,
+                'b.txt': null
+            },
+            'file1.txt': null
+        };
+        sftp = mockSFTP(vfs);
+        callback = jest.fn();
+    })
+
+    describe('readdir', () => {
+        it('returns directory contents', () => {
+            sftp.readdir('/dir2', callback);
+
+            expect(callback).toBeCalled();
+
+            const [err, entries] = callback.mock.calls[0]
+            expect(err).toBeFalsy()
+            expect(entries.length).toBe(2);
+            expect(entries[0].filename).toBe('a.txt')
+            expect(entries[1].filename).toBe('b.txt')
+        })
+
+        it('returns file type attribute in longname', () => {
+            sftp.readdir('/', callback);
+
+            expect(callback).toBeCalled();
+
+            const [err, entries] = callback.mock.calls[0]
+            expect(err).toBeFalsy()
+
+            expect(entries.find((e) => e.filename === 'dir1').longname).toMatch(/^d/);
+            expect(entries.find((e) => e.filename === 'file1.txt').longname).toMatch(/^-/);
+        })
+
+        it("fail on non-directory", () => {
+            sftp.readdir('/file1.txt', callback);
+
+            expect(callback).toBeCalled();
+
+            var [err] = callback.mock.calls[0]
+            expect(err).toBeTruthy();
+        })
+
+        it("fail on non-existing directory", () => {
+            sftp.readdir('/non-existing-dir', callback);
+
+            expect(callback).toBeCalled();
+
+            const [err] = callback.mock.calls[0]
+            expect(err).toBeTruthy();
+        })
+    })
+
+    describe('unlink', () => {
+        it('deletes file', () => {
+            sftp.unlink('/file1.txt', callback);
+
+            expect(vfs['file1.txt']).toBeUndefined();
+            expect(callback).toBeCalled();
+
+            const [err] = callback.mock.calls[0]
+            expect(err).toBeFalsy();
+        })
+
+        it('records deletions in order', () => {
+            sftp.unlink('/dir2/a.txt', callback);
+            sftp.unlink('/dir2/b.txt', callback);
+            
+            expect(sftp.deletions.length).toBe(2);
+            expect(sftp.deletions[0]).toBe('/dir2/a.txt');
+            expect(sftp.deletions[1]).toBe('/dir2/b.txt');
+        })
+
+        it('fails on directories', () => {
+            sftp.unlink('/dir1', callback);
+            
+            expect(sftp.deletions.length).toBe(0)
+            expect(callback).toBeCalled();
+
+            const [err] = callback.mock.calls[0]
+            expect(err).toBeTruthy();
+        })
+
+        it('fails on non-existing files', () => {
+            sftp.unlink('/non-existing-file.txt', callback);
+            
+            expect(sftp.deletions.length).toBe(0)
+            expect(callback).toBeCalled();
+
+            const [err] = callback.mock.calls[0]
+            expect(err).toBeTruthy();
+        })
+    })
+
+    describe('rmmdir', () => {
+        it('deletes empty directories', () => {
+            sftp.rmdir('/dir1', callback);
+
+            expect(sftp.deletions.length).toBe(1);
+            expect(sftp.deletions[0]).toBe('/dir1');
+            expect(callback).toBeCalled();
+
+            const [err] = callback.mock.calls[0]
+            expect(err).toBeFalsy();
+        })
+
+        it('fails on files', () => {
+            sftp.rmdir('/file1.txt', callback);
+
+            expect(sftp.deletions.length).toBe(0)
+            expect(callback).toBeCalled();
+
+            const [err] = callback.mock.calls[0]
+            expect(err).toBeTruthy();
+        })
+
+        it('fails on non-existing directories', () => {
+            sftp.rmdir('/non-existing-directory', callback);
+
+            expect(sftp.deletions.length).toBe(0)
+            expect(callback).toBeCalled();
+
+            const [err] = callback.mock.calls[0]
+            expect(err).toBeTruthy();
+        })
+    })
+})
+
+describe('clearDirectory', () => {
+    let callback;
+
+    beforeEach(() => {
+        callback = jest.fn();
+    })
+
+    it('keeps clearing destination root directory', () => {
+        const sftp = mockSFTP({ 'dir': {} })
+
+        clearDirectory(sftp, '/dir', callback);
+
+        expect(sftp.deletions.length).toBe(0);
+        expect(callback).toBeCalled();
+
+        const [err] = callback.mock.calls[0]
+        expect(err).toBeFalsy();
+    })
+
+    it('deletes contents before deleting a directory', () => {
+        const sftp = mockSFTP({
+            'dir': {
+                'file1.txt': null,
+                'file2.txt': null
+            }
+        })
+
+        clearDirectory(sftp, '/', callback);
+
+        expect(sftp.readdir).toBeCalled();
+        expect(callback).toBeCalled();
+
+        const [err] = callback.mock.calls[0]
+        expect(err).toBeFalsy();
+
+        expect(sftp.deletions.length).toBe(3);
+        expect(sftp.deletions[0]).toBe('/dir/file1.txt');
+        expect(sftp.deletions[1]).toBe('/dir/file2.txt');
+        expect(sftp.deletions[2]).toBe('/dir');
+    })
+})

--- a/index.js
+++ b/index.js
@@ -126,7 +126,6 @@ module.exports = function (options) {
             gutil.log('Authenticating with private key.');
         }
 
-        var self = this;
         var c = new Connection();
         connectionCache = c;
         c.on('ready', function() {
@@ -155,6 +154,7 @@ module.exports = function (options) {
             });//c.sftp
         });//c.on('ready')
 
+        var self = this;
         c.on('error', function(err) {
             self.emit('error', new gutil.PluginError('gulp-sftp', err));
             //return cb(err);

--- a/package.json
+++ b/package.json
@@ -18,12 +18,15 @@
     "Carson Britt <carson28@gmail.com> <carson.britt@a0002457.local>",
     "Matthew Drake <mdrake@mediadrake.com>",
     "Valan Brown <github@valanbrown.com>",
-    "Sorin Guga <sorin.guga@gmail.com>"
+    "Sorin Guga <sorin.guga@gmail.com>",
+    "Sergii Rudchenko <rudchenkos@gmail.com>"
   ],
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=6.11.1"
   },
-  "scripts": {},
+  "scripts": {
+    "test": "jest"
+  },
   "files": [
     "index.js"
   ],
@@ -48,5 +51,7 @@
     "ssh2": "~0.3.3",
     "through2": "~0.4.2"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "jest": "^20.0.4"
+  }
 }


### PR DESCRIPTION
Sometimes it is needed to ensure that no old files are left
in the remote destination directory. This commit introduces
the new option `clearDestination` which makes gulp-sftp delete
everything from `remotePath` before uploading files.