### PR TITLE
Updated ssh2 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-sftp",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Upload files via SSH",
   "license": "MIT",
   "repository": "gtg092x/gulp-sftp",
@@ -45,7 +45,7 @@
     "gulp-util": "~3.0.0",
     "object-assign": "~0.3.1",
     "parents": "~1.0.0",
-    "ssh2": "~0.3.3",
+    "ssh2": "~0.6.1",
     "through2": "~0.4.2"
   },
   "devDependencies": {}


### PR DESCRIPTION
Ran in to an issue with Node.js compatibility. Upgraded to the latest ssh2 which addresses compatibility issues.